### PR TITLE
Fix code scanning alert no. 3: Cross-site scripting

### DIFF
--- a/sso-ch1-hello/sso-ch1-resource-jwks/src/main/java/com/chensoul/controller/ResourceController.java
+++ b/sso-ch1-hello/sso-ch1-resource-jwks/src/main/java/com/chensoul/controller/ResourceController.java
@@ -2,6 +2,7 @@
 package com.chensoul.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.util.HtmlUtils;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,6 +27,6 @@ public class ResourceController {
 
     @PostMapping("/message")
     public String createMessage(@RequestBody String message) {
-        return String.format("Message was created. Content: %s", message);
+        return String.format("Message was created. Content: %s", HtmlUtils.htmlEscape(message));
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/chensoul/spring-security-6-oauth2-samples/security/code-scanning/3](https://github.com/chensoul/spring-security-6-oauth2-samples/security/code-scanning/3)

To fix the cross-site scripting vulnerability, we need to ensure that any user-provided input is properly sanitized or encoded before being included in the response. In this case, we can use the `HtmlUtils.htmlEscape` method from the `org.springframework.web.util` package to escape the `message` parameter before including it in the response.

- We will import the `HtmlUtils` class.
- We will use the `HtmlUtils.htmlEscape` method to escape the `message` parameter before including it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
