### PR TITLE
Fix code scanning alert no. 1: Cross-site scripting

### DIFF
--- a/sso-ch1-hello/sso-ch1-resource-multi-tenant/pom.xml
+++ b/sso-ch1-hello/sso-ch1-resource-multi-tenant/pom.xml
@@ -17,6 +17,11 @@
     </properties>
 
     <dependencies>
+    <dependency>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-text</artifactId>
+    <version>1.12.0</version>
+    </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>

--- a/sso-ch1-hello/sso-ch1-resource-multi-tenant/src/main/java/com/chensoul/ResourceController.java
+++ b/sso-ch1-hello/sso-ch1-resource-multi-tenant/src/main/java/com/chensoul/ResourceController.java
@@ -5,6 +5,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+import org.apache.commons.text.StringEscapeUtils;
 
 @RestController
 public class ResourceController {
@@ -13,12 +14,14 @@ public class ResourceController {
 	public String index(@AuthenticationPrincipal OAuth2AuthenticatedPrincipal token,
 			@PathVariable("tenantId") String tenantId) {
 		String subject = token.getAttribute("sub");
-		return String.format("Hello, %s for %s!", subject, tenantId);
+		String escapedTenantId = StringEscapeUtils.escapeHtml4(tenantId);
+		return String.format("Hello, %s for %s!", subject, escapedTenantId);
 	}
 
 	@GetMapping("/{tenantId}/message")
 	public String message(@PathVariable("tenantId") String tenantId) {
-		return String.format("secret message for %s", tenantId);
+		String escapedTenantId = StringEscapeUtils.escapeHtml4(tenantId);
+		return String.format("secret message for %s", escapedTenantId);
 	}
 
 }


### PR DESCRIPTION
Fixes [https://github.com/chensoul/spring-security-6-oauth2-samples/security/code-scanning/1](https://github.com/chensoul/spring-security-6-oauth2-samples/security/code-scanning/1)

To fix the XSS vulnerability, we need to ensure that the `tenantId` is properly sanitized or encoded before being included in the response. The best way to do this is to use a library that provides HTML escaping functionality to prevent XSS attacks. In Java, the `StringEscapeUtils` class from the Apache Commons Text library can be used for this purpose.

1. Add the Apache Commons Text library to the project dependencies if it is not already included.
2. Import the `StringEscapeUtils` class in the `ResourceController` class.
3. Use the `StringEscapeUtils.escapeHtml4` method to escape the `tenantId` before including it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
